### PR TITLE
JSC and Nashorn runners

### DIFF
--- a/lib/ChakraRunner.js
+++ b/lib/ChakraRunner.js
@@ -1,12 +1,13 @@
 'use strict';
 
 const fs = require('fs');
+const inception = require('./inception');
 const ConsoleRunner = require('./ConsoleRunner');
 
-
-let runtimeStr = fs.readFileSync(__dirname + '/../runtimes/chakra.js', 'utf8').replace(/\r?\n/g, '');
-const runtimeInception = runtimeStr.replace('$SOURCE', '""');
-runtimeStr = runtimeStr.replace('$SOURCE', JSON.stringify(runtimeInception));
+const runtimeStr = inception(
+  fs.readFileSync(__dirname + '/../runtimes/chakra.js', 'utf8')
+    .replace(/\r?\n/g, '')
+);
 
 class ChakraRunner extends ConsoleRunner {
   parseError(str) {

--- a/lib/ConsoleRunner.js
+++ b/lib/ConsoleRunner.js
@@ -36,7 +36,7 @@ class ConsoleRunner extends Runner {
           result.error = this.parseError(stdout) || null;
         }
 
-        d.resolve(result)
+        d.resolve(result);
       }.bind(this));
     }).catch(err => {
       d.reject(err);

--- a/lib/D8Runner.js
+++ b/lib/D8Runner.js
@@ -1,13 +1,16 @@
 'use strict';
 
+const fs = require('fs');
+const inception = require('./inception');
 const ConsoleRunner = require('./ConsoleRunner');
 const ErrorParser = require('./parseError.js');
-const errorRe = /^(.*?):(\d+): ((\w+): (.*))[\w\W]*\3((:?\s+at.*\r?\n)*)$/m
-const fs = require('fs');
 
-let runtimeStr = fs.readFileSync(__dirname + '/../runtimes/d8.js', 'utf8').replace(/\r?\n/g, '');
-const runtimeInception = runtimeStr.replace('$SOURCE', '""');
-runtimeStr = runtimeStr.replace('$SOURCE', JSON.stringify(runtimeInception));
+const errorRe = /^(.*?):(\d+): ((\w+): (.*))[\w\W]*\3((:?\s+at.*\r?\n)*)$/m;
+
+const runtimeStr = inception(
+  fs.readFileSync(__dirname + '/../runtimes/d8.js', 'utf8')
+    .replace(/\r?\n/g, '')
+);
 
 class D8Runner extends ConsoleRunner {
   parseError(str) {

--- a/lib/JSCRunner.js
+++ b/lib/JSCRunner.js
@@ -1,0 +1,90 @@
+'use strict';
+
+const fs = require('fs');
+const temp = require('temp');
+const inception = require('./inception');
+const ConsoleRunner = require('./ConsoleRunner');
+
+const errorRe = /^(?:.*?): (\w+)(?:: (.*))$/m;
+
+// JSC stack frame format:
+// StackFrames: StackFrame+
+// StackFrame: FunctionFrame | NativeFrame | EvalMarker
+// FunctionFrame: (FunctionName`@`)?SourceInfo
+// NativeFrame: (FunctionName`@`)?`[native code]`
+// FunctionName: .*
+// SourceInfo: File`:`Line`:`Column
+// File: .*
+// Line: \d+
+// Column: \d+
+// EvalMarker: `eval code`
+const frameRe = /(?:(.*)@)?(\[native code\]|(?:(.*):(\d+):(\d+)))/;
+
+const newGlobalTempFile = temp.path({ suffix: '.js' });
+fs.writeFileSync(newGlobalTempFile, 'arguments[0](this);');
+
+process.addListener('exit', function() {
+  try {
+    fs.unlinkSync(newGlobalTempFile);
+  } catch (e) {
+    // ignore
+  }
+});
+
+const runtimeStr = inception(
+  fs.readFileSync(__dirname + '/../runtimes/jsc.js', 'utf8')
+    .replace('$FILE', JSON.stringify(newGlobalTempFile))
+    .replace(/\r?\n/g, '')
+);
+
+function parseStack(stackStr) {
+  const stack = [];
+
+  const lines = stackStr.split(/\r?\n/g);
+  lines.forEach(entry => {
+    const match = entry.match(frameRe);
+    if (match === null) {
+      return;
+    }
+
+    stack.push({
+      source: entry,
+      functionName: (match[1] || '').trim(),
+      fileName: match[3] || match[2],
+      lineNumber: Number(match[4]),
+      columnNumber: Number(match[5])
+    });
+  });
+
+  // Add dummy frame if no stack frames are present in stack string.
+  if (stack.length === 0) {
+    stack.push({
+      source: '',
+      functionName: '',
+      fileName: '',
+      lineNumber: 1,
+      columnNumber: 1
+    });
+  }
+
+  return stack;
+}
+
+class JSCRunner extends ConsoleRunner {
+  parseError(str) {
+    const match = str.match(errorRe);
+
+    if (!match) {
+      return null;
+    }
+
+    return {
+      name: match[1],
+      message: match[2],
+      stack: parseStack(str.slice(match[0].length))
+    };
+  }
+}
+JSCRunner.runtime = runtimeStr;
+
+module.exports = JSCRunner;

--- a/lib/JSCRunner.js
+++ b/lib/JSCRunner.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const fs = require('fs');
-const temp = require('temp');
 const inception = require('./inception');
 const ConsoleRunner = require('./ConsoleRunner');
 
@@ -20,20 +19,9 @@ const errorRe = /^(?:.*?): (\w+)(?:: (.*))$/m;
 // EvalMarker: `eval code`
 const frameRe = /(?:(.*)@)?(\[native code\]|(?:(.*):(\d+):(\d+)))/;
 
-const newGlobalTempFile = temp.path({ suffix: '.js' });
-fs.writeFileSync(newGlobalTempFile, 'arguments[0](this);');
-
-process.addListener('exit', function() {
-  try {
-    fs.unlinkSync(newGlobalTempFile);
-  } catch (e) {
-    // ignore
-  }
-});
-
 const runtimeStr = inception(
   fs.readFileSync(__dirname + '/../runtimes/jsc.js', 'utf8')
-    .replace('$FILE', JSON.stringify(newGlobalTempFile))
+    .replace('$FILE', JSON.stringify(__dirname + '/../runtimes/jsc-create.js'))
     .replace(/\r?\n/g, '')
 );
 

--- a/lib/NashornRunner.js
+++ b/lib/NashornRunner.js
@@ -1,0 +1,44 @@
+'use strict';
+
+const fs = require('fs');
+const inception = require('./inception');
+const ConsoleRunner = require('./ConsoleRunner');
+
+const errorRe = /^(.*?):(\d+):(\d+)(?: (\w+):)? (.*)$/m;
+
+const runtimeStr = inception(
+  fs.readFileSync(__dirname + '/../runtimes/nashorn.js', 'utf8')
+    .replace(/\r?\n/g, '')
+);
+
+class NashornRunner extends ConsoleRunner {
+  createChildProcess(args) {
+    args = args || [];
+    args.unshift('--language=es6');
+    return super.createChildProcess(args);
+  }
+
+  parseError(str) {
+    const error = {};
+    const match = str.match(errorRe);
+
+    if (!match) {
+      return null;
+    }
+
+    error.name = match[4] || 'SyntaxError';
+    error.message = match[5];
+
+    error.stack = [{
+      source: match[0],
+      fileName: match[1],
+      lineNumber: match[2],
+      columnNumber: match[3]
+    }];
+
+    return error;
+  }
+}
+NashornRunner.runtime = runtimeStr;
+
+module.exports = NashornRunner;

--- a/lib/NodeRunner.js
+++ b/lib/NodeRunner.js
@@ -1,13 +1,16 @@
 'use strict';
 
+const fs = require('fs');
+const inception = require('./inception');
 const ConsoleRunner = require('./ConsoleRunner');
 const ErrorParser = require('./parseError.js');
-const fs = require('fs');
-const errorRe = /^(.*?):(\d+): ((\w+): (.*))[\w\W]*\3((:?\s+at.*\r?\n)*)$/m
 
-let runtimeStr = fs.readFileSync(__dirname + '/../runtimes/node.js', 'utf8').replace(/\r?\n/g, '');
-const runtimeInception = runtimeStr.replace('$SOURCE', '""');
-runtimeStr = runtimeStr.replace('$SOURCE', JSON.stringify(runtimeInception));
+const errorRe = /^(.*?):(\d+): ((\w+): (.*))[\w\W]*\3((:?\s+at.*\r?\n)*)$/m;
+
+const runtimeStr = inception(
+  fs.readFileSync(__dirname + '/../runtimes/node.js', 'utf8')
+    .replace(/\r?\n/g, '')
+);
 
 class NodeRunner extends ConsoleRunner {
   compile(code) {

--- a/lib/SMRunner.js
+++ b/lib/SMRunner.js
@@ -1,13 +1,15 @@
 'use strict';
 
-const ConsoleRunner = require('./ConsoleRunner');
 const fs = require('fs');
+const inception = require('./inception');
+const ConsoleRunner = require('./ConsoleRunner');
 
-let runtimeStr = fs.readFileSync(__dirname + '/../runtimes/sm.js', 'utf8').replace(/\r?\n/g, '');
-const runtimeInception = runtimeStr.replace('$SOURCE', '""');
-runtimeStr = runtimeStr.replace('$SOURCE', JSON.stringify(runtimeInception));
+const errorRe = /^(.*?):(\d+):(\d+) (\w+): (.*)$/m;
 
-const errorRe = /^(.*?):(\d+):(\d+) (\w+): (.*)$/m
+const runtimeStr = inception(
+  fs.readFileSync(__dirname + '/../runtimes/sm.js', 'utf8')
+    .replace(/\r?\n/g, '')
+);
 
 class SMRunner extends ConsoleRunner {
   parseError(str) {

--- a/lib/runify.js
+++ b/lib/runify.js
@@ -6,6 +6,7 @@ const SMRunner = require('./SMRunner.js');
 const D8Runner = require('./D8Runner.js');
 const NodeRunner = require('./NodeRunner.js');
 const BrowserRunner = require('./BrowserRunner.js');
+const JSCRunner = require('./JSCRunner.js');
 
 exports.getRunner = function (path, type, args) {
   if (type === 'ch') {
@@ -18,6 +19,8 @@ exports.getRunner = function (path, type, args) {
     return new D8Runner(path, args);
   } else if (type === 'browser') {
     return new BrowserRunner(path, args);
+  } else if (type === 'jsc') {
+    return new JSCRunner(path, args);
   } else {
     throw new Error("Unknown runner type: " + type);
   }

--- a/lib/runify.js
+++ b/lib/runify.js
@@ -7,6 +7,7 @@ const D8Runner = require('./D8Runner.js');
 const NodeRunner = require('./NodeRunner.js');
 const BrowserRunner = require('./BrowserRunner.js');
 const JSCRunner = require('./JSCRunner.js');
+const NashornRunner = require('./NashornRunner.js');
 
 exports.getRunner = function (path, type, args) {
   if (type === 'ch') {
@@ -21,6 +22,8 @@ exports.getRunner = function (path, type, args) {
     return new BrowserRunner(path, args);
   } else if (type === 'jsc') {
     return new JSCRunner(path, args);
+  } else if (type === 'nashorn') {
+    return new NashornRunner(path, args);
   } else {
     throw new Error("Unknown runner type: " + type);
   }

--- a/runtimes/d8.js
+++ b/runtimes/d8.js
@@ -7,6 +7,8 @@ var $ = {
     Realm.eval(realm, this.source);
     var $child = Realm.shared;
     $child.realm = realm;
+    $child.source = this.source;
+    Realm.shared = void 0;
 
     for(var glob in globals) {
       $child.setGlobal(glob, globals[glob]);
@@ -30,9 +32,9 @@ var $ = {
       if (errorCb) errorCb(e);
     }
   },
-  source: $SOURCE,
   setGlobal: function (name, value) {
     this.global[name] = value;
-  }
+  },
+  source: $SOURCE
 };
 Realm.shared = $;

--- a/runtimes/jsc-create.js
+++ b/runtimes/jsc-create.js
@@ -1,0 +1,2 @@
+// arguments[0] is the callback function defined in $.createRealm().
+arguments[0](this);

--- a/runtimes/jsc.js
+++ b/runtimes/jsc.js
@@ -1,0 +1,41 @@
+var $ = {
+  global: this,
+  createRealm(globals) {
+    globals = globals || {};
+
+    var realm;
+    run(this.file, function(newRealm) {
+      realm = newRealm;
+    });
+    realm.eval(this.source);
+    realm.$.source = this.source;
+
+    for(var glob in globals) {
+      realm.$.global[glob] = globals[glob];
+    }
+
+    return realm.$;
+  },
+  evalInNewRealm(code, globals, errorCb) {
+    if (typeof globals === 'function') {
+      errorCb = globals;
+      globals = {};
+    }
+
+    var $child = this.createRealm(globals);
+    $child.evalInNewScript(code, errorCb);
+  },
+  evalInNewScript(code, errorCb) {
+    try {
+      /* FIXME: `code` should be executed as a global script, not an eval script. */
+      this.global.eval(code);
+    } catch (e) {
+      if (errorCb) errorCb(e);
+    }
+  },
+  setGlobal(name, value) {
+    this.global[name] = value;
+  },
+  source: $SOURCE,
+  file: $FILE
+};

--- a/runtimes/nashorn.js
+++ b/runtimes/nashorn.js
@@ -1,0 +1,36 @@
+var $ = {
+  global: this,
+  createRealm: function(globals) {
+    globals = globals || {};
+
+    var realm = loadWithNewGlobal({script: 'this', name: 'createRealm'});
+    realm.eval(this.source);
+    realm.$.source = this.source;
+
+    for(var glob in globals) {
+      realm.$.global[glob] = globals[glob];
+    }
+
+    return realm.$;
+  },
+  evalInNewRealm: function(code, globals, errorCb) {
+    if (typeof globals === 'function') {
+      errorCb = globals;
+      globals = {};
+    }
+
+    var $child = this.createRealm(globals);
+    $child.evalInNewScript(code, errorCb);
+  },
+  evalInNewScript: function(code, errorCb) {
+    try {
+      load({script: code, name: 'evalInNewScript'});
+    } catch (e) {
+      if (errorCb) errorCb(e);
+    }
+  },
+  setGlobal: function(name, value) {
+    this.global[name] = value;
+  },
+  source: $SOURCE
+};

--- a/runtimes/sm.js
+++ b/runtimes/sm.js
@@ -3,7 +3,7 @@ var $ = {
   createRealm(globals) {
     globals = globals || {};
 
-    realm = newGlobal();
+    var realm = newGlobal();
     realm.eval(this.source);
     realm.$.source = this.source;
 
@@ -19,7 +19,7 @@ var $ = {
       globals = {};
     }
 
-    $child = this.createRealm(globals);
+    var $child = this.createRealm(globals);
     $child.evalInNewScript(code, errorCb);
   },
   evalInNewScript(code, errorCb) {

--- a/test/runify.js
+++ b/test/runify.js
@@ -157,6 +157,10 @@ hosts.forEach(function (record) {
     });
 
     it('can eval lexical bindings in new scripts', function () {
+      if (type === 'jsc') {
+        // Skip test for JavaScriptCore, see fixme in runtimes/jsc.js.
+        this.skip();
+      }
       return runner.exec(`
         $.evalInNewScript("'use strict'; let x = 3;");
         print(x);


### PR DESCRIPTION
A small :gift: for you! :smile: 

I had to disable the 'can eval lexical bindings in new scripts' test for JSC, because I haven't found a way to run arbitrary code as global script code in JSC. 

Tested all changes with JSC, Node, SM, V8 (recent builds from tip/master); Nashorn (JDK8 and JDK9b96).

(The first commit is only clean-up, so you can skip that one if you feel it's not necessary to include it.)